### PR TITLE
Fixed broken colab links and replaced '-' with '_'

### DIFF
--- a/Exercises/Exercise_13_Algorithm_Representation.ipynb
+++ b/Exercises/Exercise_13_Algorithm_Representation.ipynb
@@ -10,7 +10,7 @@
     "Related Notes:\n",
     "- Chapter_08_Algorithmic_Representation\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise-13-Algorithm-Representation.ipynb) "
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise_13_Algorithm_Representation.ipynb) "
    ]
   },
   {

--- a/Exercises/Exercise_14_Object_Oriented_Programming_part_un.ipynb
+++ b/Exercises/Exercise_14_Object_Oriented_Programming_part_un.ipynb
@@ -10,7 +10,7 @@
     "Related Notes:\n",
     "- Chapter_09_Object_Oriented_Programming\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise-14-Object-Oriented-Programming.ipynb) "
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise_14_Object_Oriented_Programming_part_un.ipynb) "
    ]
   },
   {

--- a/Exercises/Exercise_15_Object_Oriented_Programming_part_deux.ipynb
+++ b/Exercises/Exercise_15_Object_Oriented_Programming_part_deux.ipynb
@@ -11,7 +11,7 @@
     "- Chapter_09_Object_Oriented_Programming\n",
     "- Exercise 14\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise-15-Object-Oriented-Programming-part-Deux.ipynb) \n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise_15_Object_Oriented_Programming_part_deux.ipynb) \n",
     "\n",
     "For Exercises 15.1, refer back to the `Complex` class you defined in Exercise 14. "
    ]

--- a/Exercises/Exercise_16_SQL_Databases.ipynb
+++ b/Exercises/Exercise_16_SQL_Databases.ipynb
@@ -10,7 +10,7 @@
     "Related Notes:\n",
     "- Chapter_10_SQL-Databases\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise-16-SQL-Databases.ipynb) "
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise_16_SQL_Databases.ipynb) "
    ]
   },
   {

--- a/Exercises/Exercise_17_Fundamental_Algorithms_part_one.ipynb
+++ b/Exercises/Exercise_17_Fundamental_Algorithms_part_one.ipynb
@@ -10,7 +10,7 @@
     "Related Notes:\n",
     "- Chapter_11_Fundamental_Algorithms\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise-17-Fundamental-Algorithms.ipynb) "
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise_17_Fundamental_Algorithms_part_one.ipynb) "
    ]
   },
   {

--- a/Exercises/Exercise_18_Fundamental_Algorithms_part_two.ipynb
+++ b/Exercises/Exercise_18_Fundamental_Algorithms_part_two.ipynb
@@ -8,7 +8,9 @@
     "# Exercise 18\n",
     "\n",
     "Related Notes:\n",
-    "- Fundamentals_11-Fundamental_Algorithms"
+    "- Fundamentals_11-Fundamental_Algorithms\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise_18_Fudamental_Algorithms_part_two.ipynb) "
    ]
   },
   {

--- a/Exercises/Exercise_19_Data_And_Information.ipynb.ipynb
+++ b/Exercises/Exercise_19_Data_And_Information.ipynb.ipynb
@@ -8,14 +8,16 @@
     "# Exercise 19\n",
     "\n",
     "Related Notes :\n",
-    "- Fundamentals_13-Data_And_Information"
+    "- Fundamentals_13-Data_And_Information\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise_19_Data_And_Information.ipynb) "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exercise 18.1 2016/A Level/P1/Q4 H2 Computing\n",
+    "## Exercise 19.1 2016/A Level/P1/Q4 H2 Computing\n",
     "\n",
     "Numbers in Computing are often represented in hexadecimal form.\n",
     "A program is required to convert a hexadecimal number into a denary number and vice versa.\n",

--- a/Exercises/Exercise_20_Abstract_Data_Types_part_one.ipynb
+++ b/Exercises/Exercise_20_Abstract_Data_Types_part_one.ipynb
@@ -8,7 +8,9 @@
     "# Exercise 20\n",
     "\n",
     "Related Notes:\n",
-    "- Fundamentals_14-Abstract_Data_Types"
+    "- Fundamentals_14-Abstract_Data_Types\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise_20_Abstract_Data_Types_part_one.ipynb)"
    ]
   },
   {

--- a/Exercises/Exercise_21_Abstract_Data_Types_part_two.ipynb
+++ b/Exercises/Exercise_21_Abstract_Data_Types_part_two.ipynb
@@ -8,7 +8,9 @@
     "# Exercise 21\n",
     "\n",
     "Related Notes:\n",
-    "- Fundamentals_14_Abstract_Data_Types"
+    "- Fundamentals_14_Abstract_Data_Types\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise_21_Abstract_Data_Types_part_two.ipynb)"
    ]
   },
   {

--- a/Exercises/Exercise_22_Abstract_Data_Types_part_three.ipynb
+++ b/Exercises/Exercise_22_Abstract_Data_Types_part_three.ipynb
@@ -8,7 +8,9 @@
     "# Exercise 22\n",
     "\n",
     "Related Notes:\n",
-    "- Fundamentals_14_Abstract_Data_Types"
+    "- Fundamentals_14_Abstract_Data_Types\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise_22_Abstract_Data_Types_part_three.ipynb)"
    ]
   },
   {

--- a/Exercises/Exercise_23_NoSQL_Database.ipynb
+++ b/Exercises/Exercise_23_NoSQL_Database.ipynb
@@ -9,7 +9,7 @@
     "Notes:\n",
     "- Chapter_15_NoSQL_Databases\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/googlecolab/colabtools/blob/master/notebooks/colab-github-demo.ipynb) FIX LINK"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise_23_NOSQL_Database.ipynb)"
    ]
   },
   {

--- a/Exercises/Exercise_24_Networking.ipynb
+++ b/Exercises/Exercise_24_Networking.ipynb
@@ -6,7 +6,9 @@
    "source": [
     "# Exercise 24\n",
     "Notes:\n",
-    "- Chapter 16 Networking"
+    "- Chapter 16 Networking\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/njc-cz2-2021/Materials/blob/main/Exercises/Exercise_24_Networking.ipynb)"
    ]
   },
   {

--- a/Notes/Chapter_07_HTML_And_CSS.ipynb
+++ b/Notes/Chapter_07_HTML_And_CSS.ipynb
@@ -576,7 +576,7 @@
     "pip install flask\n",
     "```\n",
     "\n",
-    "Note: Flask version for A-level is 0.12.2 when the current Flask version is 3.1.x.\n",
+    "Note: Flask version for A-level is 2.2.5 when the current Flask version is 3.1.x.\n",
     "\n",
     "Basic code to run a Flask web server is given below:"
    ]


### PR DESCRIPTION
Previously, exercise filenames were inconsistent with using '_' and '-'.
(e.g. Exercise_13_Algorithm-Representation.ipynb)

Furthermore, some files had missing or broken colab links
An example is Exercise_23_NOSQL_Database.ipynb:
![image](https://github.com/user-attachments/assets/16464430-a8c6-4b3a-aff7-008c3c6a9cdf)

This pull request aims to fix both of these problems